### PR TITLE
添加工科数学分析（下）期末试卷

### DIFF
--- a/metadata/7b15ce3520afe74c3ee374a9a3e0a17c.yml
+++ b/metadata/7b15ce3520afe74c3ee374a9a3e0a17c.yml
@@ -8,7 +8,7 @@ data:
   - 信息与通信工程学院
   course:
     type: 本科
-    name: 工科数学分析（下）
+    name: 数学分析（下）
   time:
     start: '2022'
     end: '2023'

--- a/metadata/7b15ce3520afe74c3ee374a9a3e0a17c.yml
+++ b/metadata/7b15ce3520afe74c3ee374a9a3e0a17c.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://byrdocs.org/schema/test.yaml
+
+id: 7b15ce3520afe74c3ee374a9a3e0a17c
+url: https://byrdocs.org/files/7b15ce3520afe74c3ee374a9a3e0a17c.pdf
+type: test
+data:
+  college:
+  - 信息与通信工程学院
+  course:
+    type: 本科
+    name: 工科数学分析（下）
+  time:
+    start: '2022'
+    end: '2023'
+    semester: Second
+    stage: 期末
+  filetype: pdf
+  content:
+  - 原题

--- a/metadata/ac0beff7884ad3a42d621dbf5b1bbc9f.yml
+++ b/metadata/ac0beff7884ad3a42d621dbf5b1bbc9f.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://byrdocs.org/schema/test.yaml
+
+id: ac0beff7884ad3a42d621dbf5b1bbc9f
+url: https://byrdocs.org/files/ac0beff7884ad3a42d621dbf5b1bbc9f.pdf
+type: test
+data:
+  college:
+  - 信息与通信工程学院
+  course:
+    type: 本科
+    name: 工科数学分析（下）
+  time:
+    start: '2023'
+    end: '2024'
+    semester: Second
+    stage: 期末
+  filetype: pdf
+  content:
+  - 原题

--- a/metadata/ac0beff7884ad3a42d621dbf5b1bbc9f.yml
+++ b/metadata/ac0beff7884ad3a42d621dbf5b1bbc9f.yml
@@ -8,7 +8,7 @@ data:
   - 信息与通信工程学院
   course:
     type: 本科
-    name: 工科数学分析（下）
+    name: 数学分析（下）
   time:
     start: '2023'
     end: '2024'


### PR DESCRIPTION
This pull request adds metadata for two test files in YAML format, including details about the associated course, time period, and file content.

### Metadata additions:

* [`metadata/7b15ce3520afe74c3ee374a9a3e0a17c.yml`](diffhunk://#diff-f950eb99fc8443e68942ea9c5073c05739f63fd4583e3662d9b2bd3d76ca2730R1-R19): Added metadata for a file related to the course "工科数学分析（下）" for the 2022-2023 academic year, second semester, final stage.
* [`metadata/ac0beff7884ad3a42d621dbf5b1bbc9f.yml`](diffhunk://#diff-3c29227e410ffdc75ec0e0de804d01e4aa2792608a52075e2ccf42b3d1dcf7cdR1-R19): Added metadata for a file related to the course "工科数学分析（下）" for the 2023-2024 academic year, second semester, final stage.