### PR TITLE
Add EBU6305 test metadata

### DIFF
--- a/metadata/13561302886f3d6dfd6125179cb9ceaa.yml
+++ b/metadata/13561302886f3d6dfd6125179cb9ceaa.yml
@@ -1,0 +1,17 @@
+type: test
+id: 13561302886f3d6dfd6125179cb9ceaa
+url: https://byrdocs.org/files/13561302886f3d6dfd6125179cb9ceaa.pdf
+data:
+  college:
+    - "国际学院"
+  filetype: pdf
+  course:
+    type: "本科"
+    name: "交互式媒体设计"
+  time:
+    start: "2022"
+    end: "2023"
+    semester: "Second"
+  content:
+    - "原题"
+    - "答案"

--- a/metadata/730e3bd164151fd6b852bdfc434ca846.yml
+++ b/metadata/730e3bd164151fd6b852bdfc434ca846.yml
@@ -1,0 +1,17 @@
+type: test
+id: 730e3bd164151fd6b852bdfc434ca846
+url: https://byrdocs.org/files/730e3bd164151fd6b852bdfc434ca846.pdf
+data:
+  college:
+    - "国际学院"
+  filetype: pdf
+  course:
+    type: "本科"
+    name: "交互式媒体设计"
+  time:
+    start: "2022"
+    end: "2023"
+    semester: "Second"
+  content:
+    - "原题"
+    - "答案"


### PR DESCRIPTION
Add metadata for two EBU6305 exam PDFs.

Files:

- `metadata/730e3bd164151fd6b852bdfc434ca846.yml`
- `metadata/[电话]f3d6dfd6125179cb9ceaa.yml`

Metadata facts:

- Both PDFs are exam materials for `交互式媒体设计`.
- User confirmed the college is `国际学院`.
- User confirmed the course name is `交互式媒体设计`.
- User confirmed the semester is `Second`.
- Both files contain both `原题` and `答案`.

Validation:

- `byrdocs meta validate` passed for both files.
- `byrdocs meta preview` passed for both files with `ready_for_pr: true`.

Duplicate check:

- Search for `EBU6305 Interactive Media Design and Production solutions` returned no results.

由 BYRDocs Skill 自动生成。
