### PR TITLE
Add metadata for 西方经济学（微观部分·第八版）

### DIFF
--- a/metadata/0a928e9ab75e6585aa3e929e53836f78.yml
+++ b/metadata/0a928e9ab75e6585aa3e929e53836f78.yml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://byrdocs.org/schema/book.yaml
+id: 0a928e9ab75e6585aa3e929e53836f78
+url: https://byrdocs.org/files/0a928e9ab75e6585aa3e929e53836f78.pdf
+type: book
+data:
+  title: 西方经济学（微观部分·第八版）
+  authors:
+  - 高鸿业
+  filetype: pdf
+  isbn:
+  - '9787300294995'
+  edition: 第八版
+  publisher: 中国人民大学出版社
+  publish_year: '2021'


### PR DESCRIPTION
提交 metadata：西方经济学（微观部分·第八版）（`0a928e9ab75e6585aa3e929e53836f78`）

- 文件：https://byrdocs.org/files/0a928e9ab75e6585aa3e929e53836f78.pdf
- 类型：book
- 作者：高鸿业
- ISBN：9787300294995
- 出版社：中国人民大学出版社
- 出版年：2021
- 版次：第八版
- 校验：`meta validate` 通过（本地 schema 校验），`ready_for_pr: true`
- 查重：经 BYRDocs 搜索 API 按 ISBN/标题查重，未发现已收录条目

由 *[BYR Docs Skill](https://github.com/byrdocs/byrdocs-cli-envolved)* 自动生成