### PR TITLE
Add metadata for C++大学教程（第二版）

### DIFF
--- a/metadata/0f905f569d1d957fae3e477706140ab4.yml
+++ b/metadata/0f905f569d1d957fae3e477706140ab4.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://byrdocs.org/schema/book.yaml
+id: 0f905f569d1d957fae3e477706140ab4
+url: https://byrdocs.org/files/0f905f569d1d957fae3e477706140ab4.pdf
+type: book
+data:
+  title: C++大学教程（第二版）
+  authors:
+  - Harvey M. Deitel
+  - Paul James Deitel
+  filetype: pdf
+  isbn:
+  - '9787505367272'
+  translators:
+  - 邱仲潘
+  edition: 第二版
+  publisher: 电子工业出版社
+  publish_year: '2001'


### PR DESCRIPTION
提交 metadata：C++大学教程（第二版）（`0f905f569d1d957fae3e477706140ab4`）

- 文件：https://byrdocs.org/files/0f905f569d1d957fae3e477706140ab4.pdf
- 类型：book
- 作者：Harvey M. Deitel、Paul James Deitel
- ISBN：9787505367272
- 出版社：电子工业出版社
- 出版年：2001
- 版次：第二版
- 校验：`meta validate` 通过（本地 schema 校验），`ready_for_pr: true`
- 查重：经 BYRDocs 搜索 API 按 ISBN/标题查重，未发现已收录条目

由 *[BYR Docs Skill](https://github.com/byrdocs/byrdocs-cli-envolved)* 自动生成