### PR TITLE
Add metadata for 信息论基础（原书第2版）

### DIFF
--- a/metadata/1bee939054d2e6bf94f5dfd10e7ff7fc.yml
+++ b/metadata/1bee939054d2e6bf94f5dfd10e7ff7fc.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://byrdocs.org/schema/book.yaml
+id: 1bee939054d2e6bf94f5dfd10e7ff7fc
+url: https://byrdocs.org/files/1bee939054d2e6bf94f5dfd10e7ff7fc.pdf
+type: book
+data:
+  title: 信息论基础（原书第2版）
+  authors:
+  - Thomas M. Cover
+  - Joy A. Thomas
+  filetype: pdf
+  isbn:
+  - '9787111220404'
+  translators:
+  - 阮吉寿
+  - 张华
+  edition: 原书第2版
+  publisher: 机械工业出版社
+  publish_year: '2008'


### PR DESCRIPTION
提交 metadata：信息论基础（原书第2版）（`1bee939054d2e6bf94f5dfd10e7ff7fc`）

- 文件：https://byrdocs.org/files/1bee939054d2e6bf94f5dfd10e7ff7fc.pdf
- 类型：book
- 作者：Thomas M. Cover、Joy A. Thomas
- ISBN：9787111220404
- 出版社：机械工业出版社
- 出版年：2008
- 版次：原书第2版
- 校验：`meta validate` 通过（本地 schema 校验），`ready_for_pr: true`
- 查重：经 BYRDocs 搜索 API 按 ISBN/标题查重，未发现已收录条目

由 *[BYR Docs Skill](https://github.com/byrdocs/byrdocs-cli-envolved)* 自动生成