### PR TITLE
Add metadata for 基于内容的视觉信息检索

### DIFF
--- a/metadata/359e3dcdcbfb9bed843b79aa09989548.yml
+++ b/metadata/359e3dcdcbfb9bed843b79aa09989548.yml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://byrdocs.org/schema/book.yaml
+id: 359e3dcdcbfb9bed843b79aa09989548
+url: https://byrdocs.org/files/359e3dcdcbfb9bed843b79aa09989548.pdf
+type: book
+data:
+  title: 基于内容的视觉信息检索
+  authors:
+  - 章毓晋
+  filetype: pdf
+  isbn:
+  - '9787030113115'
+  publisher: 科学出版社
+  publish_year: '2003'


### PR DESCRIPTION
提交 metadata：基于内容的视觉信息检索（`359e3dcdcbfb9bed843b79aa09989548`）

- 文件：https://byrdocs.org/files/359e3dcdcbfb9bed843b79aa09989548.pdf
- 类型：book
- 作者：章毓晋
- ISBN：9787030113115
- 出版社：科学出版社
- 出版年：2003
- 校验：`meta validate` 通过（本地 schema 校验），`ready_for_pr: true`
- 查重：经 BYRDocs 搜索 API 按 ISBN/标题查重，未发现已收录条目

由 *[BYR Docs Skill](https://github.com/byrdocs/byrdocs-cli-envolved)* 自动生成