### PR TITLE
Add metadata for 信息论基础

### DIFF
--- a/metadata/4b3c6a74560a8a581aac834d6f61bf5a.yml
+++ b/metadata/4b3c6a74560a8a581aac834d6f61bf5a.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://byrdocs.org/schema/book.yaml
+id: 4b3c6a74560a8a581aac834d6f61bf5a
+url: https://byrdocs.org/files/4b3c6a74560a8a581aac834d6f61bf5a.pdf
+type: book
+data:
+  title: 信息论基础
+  authors:
+  - 田宝玉
+  - 杨洁
+  - 贺志强
+  - 许文俊
+  filetype: pdf
+  isbn:
+  - '9787115391513'
+  edition: 第2版
+  publisher: 人民邮电出版社
+  publish_year: '2016'


### PR DESCRIPTION
提交 metadata：信息论基础（`4b3c6a74560a8a581aac834d6f61bf5a`）

- 文件：https://byrdocs.org/files/4b3c6a74560a8a581aac834d6f61bf5a.pdf
- 类型：book
- 作者：田宝玉、杨洁、贺志强、许文俊
- ISBN：9787115391513
- 出版社：人民邮电出版社
- 出版年：2016
- 版次：第2版
- 校验：`meta validate` 通过（本地 schema 校验），`ready_for_pr: true`
- 查重：经 BYRDocs 搜索 API 按 ISBN/标题查重，未发现已收录条目

由 *[BYR Docs Skill](https://github.com/byrdocs/byrdocs-cli-envolved)* 自动生成