### PR TITLE
Add metadata for Python编程：从入门到实践（第2版）

### DIFF
--- a/metadata/dac41b16a83515231132db8f6195aa76.yml
+++ b/metadata/dac41b16a83515231132db8f6195aa76.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://byrdocs.org/schema/book.yaml
+id: dac41b16a83515231132db8f6195aa76
+url: https://byrdocs.org/files/dac41b16a83515231132db8f6195aa76.pdf
+type: book
+data:
+  title: Python编程：从入门到实践（第2版）
+  authors:
+  - Eric Matthes
+  filetype: pdf
+  isbn:
+  - '9787115546081'
+  translators:
+  - 袁国忠
+  edition: 第2版
+  publisher: 人民邮电出版社
+  publish_year: '2020'


### PR DESCRIPTION
提交 metadata：Python编程：从入门到实践（第2版）（`dac41b16a83515231132db8f6195aa76`）

- 文件：https://byrdocs.org/files/dac41b16a83515231132db8f6195aa76.pdf
- 类型：book
- 作者：Eric Matthes
- ISBN：9787115546081
- 出版社：人民邮电出版社
- 出版年：2020
- 版次：第2版
- 校验：`meta validate` 通过（本地 schema 校验），`ready_for_pr: true`
- 查重：经 BYRDocs 搜索 API 按 ISBN/标题查重，未发现已收录条目

由 *[BYR Docs Skill](https://github.com/byrdocs/byrdocs-cli-envolved)* 自动生成