### PR TITLE
Add metadata for EDA技术实用教程——Verilog HDL版

### DIFF
--- a/metadata/f177cecb759f7adb921509112154c64e.yml
+++ b/metadata/f177cecb759f7adb921509112154c64e.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://byrdocs.org/schema/book.yaml
+id: f177cecb759f7adb921509112154c64e
+url: https://byrdocs.org/files/f177cecb759f7adb921509112154c64e.pdf
+type: book
+data:
+  title: EDA技术实用教程——Verilog HDL版
+  authors:
+  - 潘松
+  - 黄继业
+  - 潘明
+  filetype: pdf
+  isbn:
+  - '9787030387820'
+  edition: 第5版
+  publisher: 科学出版社
+  publish_year: '2013'

--- a/metadata/f177cecb759f7adb921509112154c64e.yml
+++ b/metadata/f177cecb759f7adb921509112154c64e.yml
@@ -10,7 +10,7 @@ data:
   - 潘明
   filetype: pdf
   isbn:
-  - '9787030387820'
-  edition: 第5版
+  - '9787030585592'
+  edition: 第6版
   publisher: 科学出版社
-  publish_year: '2013'
+  publish_year: '2018'


### PR DESCRIPTION
提交 metadata：EDA技术实用教程——Verilog HDL版（`f177cecb759f7adb921509112154c64e`）

- 文件：https://byrdocs.org/files/f177cecb759f7adb921509112154c64e.pdf
- 类型：book
- 作者：潘松、黄继业、潘明
- ISBN：9787030387820
- 出版社：科学出版社
- 出版年：2013
- 版次：第5版
- 校验：`meta validate` 通过（本地 schema 校验），`ready_for_pr: true`
- 查重：经 BYRDocs 搜索 API 按 ISBN/标题查重，未发现已收录条目

由 *[BYR Docs Skill](https://github.com/byrdocs/byrdocs-cli-envolved)* 自动生成